### PR TITLE
bfl-internal.h: Include "config.h" before <bfd.h> to avoid error

### DIFF
--- a/libbeauty/src/input/binary_file_decoder/libbfd/bfl-internal.h
+++ b/libbeauty/src/input/binary_file_decoder/libbfd/bfl-internal.h
@@ -1,6 +1,8 @@
 #ifndef __BFL_INTERNAL__
 #define __BFL_INTERNAL__
 
+#include "config.h"
+
 #include <bfd.h>
 #include <inttypes.h>
 #include <dis-asm.h>


### PR DESCRIPTION
For more information, see:
https://sourceware.org/bugzilla/show_bug.cgi?id=14243